### PR TITLE
Limit the !online command to a specified channel-ID

### DIFF
--- a/src/com/johnymuffin/beta/discordchatbridge/DCBConfig.java
+++ b/src/com/johnymuffin/beta/discordchatbridge/DCBConfig.java
@@ -19,6 +19,7 @@ public class DCBConfig extends Configuration {
         //Setting
         generateConfigOption("server-name", "BetaServer");
         generateConfigOption("channel-id", "id");
+        generateConfigOption("bot-command-id", "id");
         generateConfigOption("presence-player-count", true);
         generateConfigOption("online-command-enabled", true);
         generateConfigOption("message.discord-chat-message", "&f[&6Discord&f]&7 %messageAuthor%: %message%");

--- a/src/com/johnymuffin/beta/discordchatbridge/DCBDiscordListener.java
+++ b/src/com/johnymuffin/beta/discordchatbridge/DCBDiscordListener.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.awt.*;
+import java.util.Objects;
 import java.util.Random;
 
 public class DCBDiscordListener extends ListenerAdapter {
@@ -33,7 +34,7 @@ public class DCBDiscordListener extends ListenerAdapter {
         String[] messageCMD = event.getMessage().getContentRaw().split(" ");
 
         //Online Command
-        if (messageCMD[0].equalsIgnoreCase("!online") && plugin.getConfig().getConfigBoolean("online-command-enabled")) {
+        if (messageCMD[0].equalsIgnoreCase("!online") && plugin.getConfig().getConfigBoolean("online-command-enabled") && Objects.equals(plugin.getConfig().getConfigString("bot-command-id"), event.getChannel().getId())) {
             String onlineMessage = "**The online players are:** ";
             for (Player p : Bukkit.getServer().getOnlinePlayers()) {
                 onlineMessage += p.getName() + ", ";


### PR DESCRIPTION
This will require a bit more work put into the other plugins that utilize Discord-Bot-Chatbridge in order to limit the commands to a single channel.